### PR TITLE
Create API endpoint that allows the open registration of new users 

### DIFF
--- a/{{cookiecutter.project_slug}}/.env
+++ b/{{cookiecutter.project_slug}}/.env
@@ -6,4 +6,5 @@ POSTGRES_SERVER=db
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD={{cookiecutter.postgres_password}}
 POSTGRES_DB=app
+USERS_OPEN_REGISTRATION=False
 

--- a/{{cookiecutter.project_slug}}/backend/app/app/api/api_v1/endpoints/user.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/api/api_v1/endpoints/user.py
@@ -112,6 +112,52 @@ def route_users_post(email=None,
 
 @docs.register
 @doc(
+    description='Create new user without the need to be logged in',
+    tags=['users'])
+@app.route(f'{config.API_V1_STR}/users/open', methods=['POST'])
+@use_kwargs({
+    'email': fields.Str(required=True),
+    'password': fields.Str(required=True),
+    'first_name': fields.Str(),
+    'last_name': fields.Str(),
+    'group_id': fields.Int(required=True),
+})
+@marshal_with(UserSchema())
+def route_users_post_open(email=None,
+                     password=None,
+                     first_name=None,
+                     last_name=None,
+                     group_id=None):
+
+    if not config.USERS_OPEN_REGISTRATION:
+        abort(403, 'Open user resgistration is forbidden on this server')
+
+    user = db_session.query(User).filter(User.email == email).first()
+
+    if user:
+        return abort(
+            400,
+            f'The user with this email already exists in the system: {email}')
+
+    group = db_session.query(Group).filter(Group.id == group_id).first()
+
+    if group is None:
+        abort(400, f'There is no group with id: "{group_id}"')
+    user = User(
+        email=email,
+        password=pwd_context.hash(password),
+        first_name=first_name,
+        last_name=last_name,
+        group=group)
+
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+@docs.register
+@doc(
     description='Get current user',
     security=security_params,
     tags=['users'])

--- a/{{cookiecutter.project_slug}}/backend/app/app/core/config.py
+++ b/{{cookiecutter.project_slug}}/backend/app/app/core/config.py
@@ -1,5 +1,12 @@
 import os
 
+def getenv_boolean(var_name, default_value=False):
+    result = default_value
+    env_value = os.getenv(var_name)
+    if not env_value is None:
+        result = env_value.upper() in ('TRUE', '1')
+    return result
+
 API_V1_STR = "/api/v1"
 
 SECRET_KEY = os.getenvb(b"SECRET_KEY")
@@ -21,3 +28,7 @@ SQLALCHEMY_DATABASE_URI = (
 
 FIRST_SUPERUSER = os.getenv("FIRST_SUPERUSER")
 FIRST_SUPERUSER_PASSWORD = os.getenv("FIRST_SUPERUSER_PASSWORD")
+
+USERS_OPEN_REGISTRATION = getenv_boolean("USERS_OPEN_REGISTRATION")
+
+

--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - POSTGRES_DB=${POSTGRES_DB}
       - FIRST_SUPERUSER={{cookiecutter.first_superuser}}
       - FIRST_SUPERUSER_PASSWORD={{cookiecutter.first_superuser_password}}
+      - USERS_OPEN_REGISTRATION=${USERS_OPEN_REGISTRATION}
   celeryworker:
     depends_on: 
       - db


### PR DESCRIPTION
This PR creates a new endpoint in the users API that allows the creation of new accounts without the need to use an authentication token.

Its utility is for the case where users can create their own accounts through the API or when the frontend is done using only static html / javascript where it would not be possible to embed in the code the login data of a super user.