### PR TITLE
update image, env-pgadmin.env variable names

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose.shared.admin.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.shared.admin.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   pgadmin:
-    image: fenglc/pgadmin4
+    image: dpage/pgadmin4
     depends_on:
       - db
     env_file:

--- a/{{cookiecutter.project_slug}}/env-pgadmin.env
+++ b/{{cookiecutter.project_slug}}/env-pgadmin.env
@@ -1,2 +1,3 @@
-PG_ADMIN_DEFAULT_USER={{cookiecutter.pgadmin_default_user}}
+PGADMIN_LISTEN_PORT=5050
+PG_ADMIN_DEFAULT_EMAIL={{cookiecutter.pgadmin_default_user}}
 PG_ADMIN_DEFAULT_PASSWORD={{cookiecutter.pgadmin_default_user_password}}


### PR DESCRIPTION
Changed to official image: https://hub.docker.com/r/dpage/pgadmin4/
Configured the official pgadmin to also listen on port 5050 (defaults to 80)

Cookiecutter user/password should now work correctly on startup


